### PR TITLE
Fix nginx routing

### DIFF
--- a/client/nginx/default.conf
+++ b/client/nginx/default.conf
@@ -9,7 +9,8 @@ server {
     # client
     location / {
         root   /usr/share/nginx/html;
-        index  index.html;
+        # https://angular.io/guide/deployment#routed-apps-must-fallback-to-indexhtml
+        try_files $uri $uri/ /index.html;
     }
 
     # https://docs.gunicorn.org/en/stable/deploy.html

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -34,7 +34,7 @@ services:
     environment:
       POSTGRES_PASSWORD:
     healthcheck:
-      test: "nc -z localhost 5432"
+      test: "pg_isready -h 127.0.0.1 || exit 1"
       start_period: 30s
     restart: on-failure
     expose:


### PR DESCRIPTION
With the production Compose file (docker-compose.prod.yml), reloading any page resulted in a 404 error due to not implementing:

https://angular.io/guide/deployment#routed-apps-must-fallback-to-indexhtml

Unrelated minor suggestion: use pg_isready instead of nc to determine if postgres is ready